### PR TITLE
Added a use_https option that defaults to true

### DIFF
--- a/lib/google-qr.rb
+++ b/lib/google-qr.rb
@@ -1,7 +1,6 @@
 class GoogleQR
-  BASE_URL = "https://chart.googleapis.com/chart?cht=qr&"
-  attr_accessor :data, :size
-  def initialize(opts={:data => "http://google.com", :size => "100x100"})
+  attr_accessor :data, :size, :use_https
+  def initialize(opts={:data => "http://google.com", :size => "100x100", :use_https => true})
     opts.each {|key,value| self.send("#{key}=", value) }
   end
 
@@ -9,7 +8,7 @@ class GoogleQR
     if self.data
       params = ["chl=#{self.data}"]
       params << "chs=#{self.size}" if self.size
-      BASE_URL + params.join("&")
+      base_url + params.join("&")
     else
       raise "Attribute @data is required for GoogleQR code"
     end
@@ -23,5 +22,9 @@ class GoogleQR
       dimensions = nil
     end
     "<img src='#{self.to_s}'#{dimensions}/>"
+  end
+  
+  def base_url
+    "http#{self.use_https ? 's' : ''}://chart.googleapis.com/chart?cht=qr&"
   end
 end

--- a/spec/google-qr_spec.rb
+++ b/spec/google-qr_spec.rb
@@ -5,10 +5,6 @@ describe "GoogleQR" do
     @qr_code = GoogleQR.new
   end
   
-  it "knows the base google api url" do
-    GoogleQR::BASE_URL.should == "https://chart.googleapis.com/chart?cht=qr&"
-  end
-  
   context "generating" do
     describe "to_s" do
       it "raises without data" do
@@ -24,6 +20,12 @@ describe "GoogleQR" do
         @qr_code.size = "200x200"
         @qr_code.to_s.should == "https://chart.googleapis.com/chart?cht=qr&chl=#{@qr_code.data}&chs=200x200"
       end
+      
+      it "renders without https if requested" do
+        @qr_code.use_https = false
+        @qr_code.to_s.should == "http://chart.googleapis.com/chart?cht=qr&chl=#{@qr_code.data}&chs=#{@qr_code.size}"
+      end
+      
     end
   
     describe "render" do


### PR DESCRIPTION
Not extremely useful but it's easy to add in so I added that in there too. Google will render the QR code over http or https.
